### PR TITLE
Update Update-Message to include the curl command for updating

### DIFF
--- a/update/check.go
+++ b/update/check.go
@@ -60,6 +60,7 @@ func Check() error {
 
 	io.Errorf(io.BoldRed("Your Scalingo client (%s) is out-of-date: some features may not work correctly.\n"), version)
 	io.Errorf(io.BoldRed("Please update to '%s' by reinstalling it: https://cli.scalingo.com\n"), lastVersion)
+	io.Errorf(io.BoldRed("Or use 'curl -O https://cli-dl.scalingo.io/install && bash install' to update from your shell.\n"))
 	return nil
 }
 


### PR DESCRIPTION
Every time I get the update notification it bothers me that I have to copy / click the link to https://cli.scalingo.com and then to copy and paste the update code from there.

So I thought why not include it in the message itself? It doesn't really seem to change that often.

NOTE: PLEASE: I HAVEN'T TESTED THIS, I HOPE THE STRING IS FINE, BUT I DON'T HAVE OR KNOW ANY GO. PLEASE VERIFY BEFORE SHIPPING THIS!

- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
